### PR TITLE
only setting columns if file is correctly parsed

### DIFF
--- a/app/src/components/pageTemplates/CommonUtils/ParseFile.js
+++ b/app/src/components/pageTemplates/CommonUtils/ParseFile.js
@@ -19,5 +19,8 @@ export const processFileColumns = async (fileData, setColumns) => {
       cols.push(col);
     }
   });
-  setColumns(cols);
+  if (cols.length > 0){
+    setColumns(cols);
+  }
+  
 };


### PR DESCRIPTION
- bug fixed where app would crash with a bad file
- fixed by only setting columns if file is successfully parsed